### PR TITLE
Changed updtURL for IPv4 to updtURL4

### DIFF
--- a/dynv6
+++ b/dynv6
@@ -17,7 +17,7 @@ if [ -z "$ipURL" ]; then
 fi
 
 updtURL="http://dynv6.com/api/update"
-
+updtURL4="http://ipv4.dynv6.com/api/update"
 
 logline(){
     echo -n "$(date +'%b %e %X') $(hostname) dynv6: $1"
@@ -52,7 +52,7 @@ if [ -n $dynv6ipv4 ]; then
     logline
     if [ "$currentipv4" != "$oldipv4" ] && [ -n $currentipv4 ]; then
         echo -n "Updating IPv4 record on server .."
-        status=$(curl -m $timeout -s "$updtURL?hostname=$hostname&ipv4=$dynv6ipv4&token=$token")
+        status=$(curl -m $timeout -s "$updtURL4?hostname=$hostname&ipv4=$dynv6ipv4&token=$token")
         errorOK $status
         case "$status" in
             'host updated')


### PR DESCRIPTION
If not using "http://ipv4.dynv6.com" for the update, than some "intermediate" IPv4 addresses are used.
